### PR TITLE
Set the page cache expiry to be equal to Cache-control.

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -5181,6 +5181,13 @@ function drupal_page_set_cache() {
   global $base_root;
 
   if (drupal_page_is_cacheable()) {
+    if (variable_get('cache_lifetime', 0)) {
+      $expire = REQUEST_TIME + variable_get('cache_lifetime', 0);
+    }
+    else {
+      $expire = CACHE_TEMPORARY;
+    }
+
     $cache = (object) array(
       'cid' => $base_root . request_uri(),
       'data' => array(
@@ -5189,7 +5196,7 @@ function drupal_page_set_cache() {
         'title' => drupal_get_title(),
         'headers' => array(),
       ),
-      'expire' => CACHE_TEMPORARY,
+      'expire' => $expire,
       'created' => REQUEST_TIME,
     );
 


### PR DESCRIPTION
By default, Drupal will clear CACHE_TEMPORARY on cron. However, this
means that at best, your cache expiry for the page cache can be no
smaller than your cron interval. Some site might set cron to run once
every 30 or 60 minutes, when they might have other data that they want
to keep fresh on the page.

By setting the expiry to be equal to the cache lifetime, we ensure that
cache_get() will return FALSE if the object is truly expired.

This is an implementation of https://drupal.org/node/1279654#comment-6473782
